### PR TITLE
Add hint to glossary

### DIFF
--- a/docs/mdcheat.md
+++ b/docs/mdcheat.md
@@ -508,6 +508,11 @@ is maintained by the W3C.
 *[HTML]: Hyper Text Markup Language  
 *[W3C]:  World Wide Web Consortium
 
+!!! hint ""
+    It's also possible to manage abbreviations centrally in a glossary. See [mkdocs-material documentation] on this matter.
+
+[mkdocs-material documentation]: https://squidfunk.github.io/mkdocs-material/reference/tooltips/#includesabbreviationsmd
+
 ## Definition Lists
 
 ```


### PR DESCRIPTION
The feature was already implemented. Surprise, surprise. This makes the issue somewhat invalid. Nevertheless a hint was added to the markdown cheatsheet to point at that there is a glossary feature.
